### PR TITLE
bump peer-dep TS

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -45,7 +45,7 @@
     "typescript": "^4.5.0"
   },
   "peerDependencies": {
-    "typescript": "^4.0.0"
+    "typescript": "^4.2.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Used `isJSDocSeeTag` was missing in TS `<4.2.0`

- [issue in TS repo](https://github.com/microsoft/TypeScript/issues/41822)
- [usage of isJSDocSeeTag in `structured-types`](https://github.com/ccontrols/structured-types/blob/v3.46.7/packages/api/src/jsdoc/parseJSDocTags.ts#L135)