### PR TITLE
fix array types

### DIFF
--- a/packages/api/src/SymbolParser.ts
+++ b/packages/api/src/SymbolParser.ts
@@ -561,6 +561,7 @@ export class SymbolParser implements ISymbolParser {
       } else if (ts.isObjectBindingPattern(node)) {
         addProperties(node.elements);
       } else if (ts.isObjectLiteralExpression(node)) {
+        prop.kind = PropKind.Object;
         addProperties(node.properties);
       } else if (ts.isIdentifier(node)) {
         if (

--- a/packages/api/src/SymbolParser.ts
+++ b/packages/api/src/SymbolParser.ts
@@ -886,6 +886,11 @@ export class SymbolParser implements ISymbolParser {
           node.elements,
           options,
         );
+      } else if (
+        ts.isIdentifier(node) &&
+        node.originalKeywordKind === ts.SyntaxKind.UndefinedKeyword
+      ) {
+        prop.kind = PropKind.Undefined;
       } else {
         switch (node.kind) {
           case ts.SyntaxKind.NumberKeyword:

--- a/packages/api/test/insta-docs/document/docs-document.test.ts
+++ b/packages/api/test/insta-docs/document/docs-document.test.ts
@@ -252,7 +252,7 @@ describe('docs-document', () => {
     expect(result).toMatchObject({
       default: {
         type: 'Document',
-        kind: 15,
+        kind: 26,
         properties: [
           {
             name: 'name',

--- a/packages/api/test/typescript/array/array-prop.test.ts
+++ b/packages/api/test/typescript/array/array-prop.test.ts
@@ -130,7 +130,6 @@ describe('array', () => {
   });
   it('holey array', () => {
     const results = parseFiles([path.resolve(__dirname, 'holey-array.ts')]);
-
     expect(results).toEqual({
       HoleyArray: {
         kind: 16,
@@ -149,6 +148,31 @@ describe('array', () => {
         name: 'HoleyArray',
         type: 'Array',
         description: 'create a new array with holes in it',
+      },
+    });
+  });
+  it('array with empty objects', () => {
+    const results = parseFiles([
+      path.resolve(__dirname, 'array-with-empty-objects.ts'),
+    ]);
+    expect(results).toEqual({
+      empty: {
+        kind: 16,
+        value: [
+          {
+            kind: 26,
+          },
+          {
+            kind: 26,
+          },
+          {
+            kind: 2,
+            value: 0,
+          },
+        ],
+        name: 'empty',
+        type: 'Array',
+        description: 'an array with emptys',
       },
     });
   });

--- a/packages/api/test/typescript/array/array-prop.test.ts
+++ b/packages/api/test/typescript/array/array-prop.test.ts
@@ -128,4 +128,28 @@ describe('array', () => {
       },
     });
   });
+  it('holey array', () => {
+    const results = parseFiles([path.resolve(__dirname, 'holey-array.ts')]);
+
+    expect(results).toEqual({
+      HoleyArray: {
+        kind: 16,
+        value: [
+          {
+            kind: 8,
+          },
+          {
+            kind: 2,
+            value: 1,
+          },
+          {
+            kind: 8,
+          },
+        ],
+        name: 'HoleyArray',
+        type: 'Array',
+        description: 'create a new array with holes in it',
+      },
+    });
+  });
 });

--- a/packages/api/test/typescript/array/array-with-empty-objects.ts
+++ b/packages/api/test/typescript/array/array-with-empty-objects.ts
@@ -1,0 +1,4 @@
+/**
+ * an array with emptys
+ */
+export const empty = [{}, {}, 0];

--- a/packages/api/test/typescript/array/holey-array.ts
+++ b/packages/api/test/typescript/array/holey-array.ts
@@ -1,0 +1,4 @@
+/**
+ * create a new array with holes in it
+ */
+export const HoleyArray = [undefined, 1, undefined];

--- a/packages/api/test/typescript/interface/interface-prop.test.ts
+++ b/packages/api/test/typescript/interface/interface-prop.test.ts
@@ -9,7 +9,7 @@ describe('interface', () => {
     expect(results).toEqual({
       default: {
         name: 'default',
-        kind: 14,
+        kind: 26,
         type: 'Person',
         properties: [
           {
@@ -46,7 +46,7 @@ describe('interface', () => {
     expect(results).toEqual({
       default: {
         name: 'Person',
-        kind: 14,
+        kind: 26,
         properties: [
           {
             name: 'title',

--- a/packages/api/test/typescript/object/object-prop.test.ts
+++ b/packages/api/test/typescript/object/object-prop.test.ts
@@ -150,7 +150,7 @@ describe('object', () => {
                   },
                 ],
                 type: 'Site',
-                kind: 15,
+                kind: 26,
               },
               {
                 name: 'facebook',
@@ -165,7 +165,7 @@ describe('object', () => {
                   },
                 ],
                 type: 'Site',
-                kind: 15,
+                kind: 26,
               },
             ],
             kind: 26,

--- a/packages/api/test/typescript/type/type-prop.test.ts
+++ b/packages/api/test/typescript/type/type-prop.test.ts
@@ -110,7 +110,7 @@ describe('type', () => {
     expect(results).toEqual({
       obj: {
         description: 'this is an object',
-        kind: 15,
+        kind: 26,
         properties: [
           {
             description: 'field a',


### PR DESCRIPTION
Fix #20

This fixes issues where holey arrays or object literals within an array where not branded with a `PropKind`. That said it appears that casted object literals where being emitted with a `PropKind.Type` or `PropKind.Interface` which does not seem correct since these values exist at runtime.

