### PR TITLE
Use uuid for helper lookups

### DIFF
--- a/packages/api-docs/src/utility/prop-links.ts
+++ b/packages/api-docs/src/utility/prop-links.ts
@@ -17,7 +17,8 @@ export class PropLinks {
   public propLink(prop: PropParent): DocumentationNode {
     const typeText = inlineCodeNode(prop.name);
     if (typeof prop.name === 'string') {
-      const link = this.getPropLink(prop.name);
+      const key = prop.token ? prop.token : prop.name;
+      const link = this.getPropLink(key);
       return linkNode(
         [typeText],
         link ? `#${link.name?.toLowerCase()}` : undefined,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,11 +36,13 @@
   },
   "license": "MIT",
   "dependencies": {
+    "uuid": "^8.3.2",
     "@structured-types/typescript-config": "^3.46.9",
     "deepmerge": "^4.2.2",
     "path-browserify": "^1.0.1"
   },
   "devDependencies": {
+    "@types/uuid": "^8.3.4",
     "@types/path-browserify": "^1.0.0",
     "typescript": "^4.5.0"
   },

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -95,6 +95,11 @@ export interface PropParent {
    * the parent type name
    */
   name: string;
+
+  /**
+   * unique id for looking up helper
+   */
+  token?: string;
   /**
    * optional source location.
    * will be available when collectSourceInfo option is set to true
@@ -197,6 +202,11 @@ export interface PropType {
    * if collectParametersUsage option is set, this will collect parameters usage in function body
    */
   usage?: { start: SourcePosition; end: SourcePosition }[];
+
+  /**
+   * unique id for looking up helpers
+   */
+  token?: string;
 }
 
 /**

--- a/packages/api/test/typescript/function/__snapshots__/function-prop.test.ts.snap
+++ b/packages/api/test/typescript/function/__snapshots__/function-prop.test.ts.snap
@@ -26,6 +26,7 @@ Object {
             "optional": true,
             "parent": Object {
               "name": "Props",
+              "token": "f3f2f08a-587d-47f0-a905-613c94dc79d6",
             },
           },
           Object {
@@ -34,6 +35,7 @@ Object {
             "optional": true,
             "parent": Object {
               "name": "PropsWithChildren",
+              "token": "b2311635-2d2a-474e-9607-8e212ad22693",
             },
             "properties": Array [
               Object {
@@ -114,6 +116,7 @@ Object {
                     "extends": Array [
                       Object {
                         "name": "ReactElement",
+                        "token": "e47515cb-210c-418b-8682-c10b830f34a0",
                       },
                     ],
                     "kind": 14,
@@ -140,6 +143,7 @@ Object {
                         "name": "type",
                         "parent": Object {
                           "name": "ReactElement",
+                          "token": "fc9257bd-9bc3-403a-a153-93112d896714",
                         },
                         "type": "T",
                       },
@@ -148,6 +152,7 @@ Object {
                         "name": "props",
                         "parent": Object {
                           "name": "ReactElement",
+                          "token": "5b3ae18f-6315-4f73-bfac-10c52bf45142",
                         },
                         "type": "P",
                       },
@@ -182,6 +187,7 @@ Object {
         "optional": true,
         "parent": Object {
           "name": "FunctionComponent",
+          "token": "ba3bf90e-4a0d-40ca-bd13-584249218941",
         },
         "properties": Array [
           Object {
@@ -204,6 +210,7 @@ Object {
         "optional": true,
         "parent": Object {
           "name": "FunctionComponent",
+          "token": "f1c5edb2-3fd4-4ee5-9c29-fc1824946215",
         },
         "properties": Array [
           Object {
@@ -226,6 +233,7 @@ Object {
         "optional": true,
         "parent": Object {
           "name": "FunctionComponent",
+          "token": "78508f56-e532-449b-8ba2-ee608fa3e1d8",
         },
         "properties": Array [
           Object {
@@ -248,6 +256,7 @@ Object {
         "optional": true,
         "parent": Object {
           "name": "FunctionComponent",
+          "token": "f8e74da5-c56f-4fab-bbe0-a66d77ebb71d",
         },
         "properties": Array [
           Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4215,6 +4215,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/yargs-parser@*":
   version "20.2.1"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"


### PR DESCRIPTION
I noticed that currently helpers are created on "first one wins" semantics because the map is [keyed off of name](https://github.com/ccontrols/structured-types/blob/master/packages/api/src/SymbolParser.ts#L103). I would like to fix this by using some unique id or hashing name + parts of `loc`. This is just draft PR to get feedback about the problem in general and see if you have some suggestions on solving the problem.