### PR TITLE
add ts v5 support on peerdeps

### DIFF
--- a/packages/api-docs/package.json
+++ b/packages/api-docs/package.json
@@ -60,7 +60,7 @@
     "@types/path-browserify": "^1.0.0"
   },
   "peerDependencies": {
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.0 || ^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -45,7 +45,7 @@
     "typescript": "^4.5.0"
   },
   "peerDependencies": {
-    "typescript": "^4.2.0"
+    "typescript": "^4.2.0 || ^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -43,7 +43,7 @@
     "typescript": "^4.5.0"
   },
   "peerDependencies": {
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.0 || ^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/react-prop-types/package.json
+++ b/plugins/react-prop-types/package.json
@@ -45,7 +45,7 @@
   "peerDependencies": {
     "prop-types": "^15.0.0",
     "react": "^16.8.0 || ^17.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.0 || ^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/react/package.json
+++ b/plugins/react/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.0 || ^5.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This just adds support for Typescript v5, since it should work the same, and right now npm install complains of peer dependencies if you are on v5.